### PR TITLE
Feature silhouette override

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,20 @@ ANewFoe is a Foundry VTT module designed to enhance the mystery and discovery of
 
 ## Usage
 
+#### GM:
+
 1. **Initialize the Module**: Ensure the module is enabled in Foundry VTT.
 2. **Configure Settings**: Adjust the settings as per your campaign needs. Visualizations and stat roll characteristics can be customized independently.
 3. **Hide and Reveal Monsters**: Use the new token hud button on each token to hide and reveal monsters during gameplay.
 4. **Manage Stat Rolls**: Approve or reject player rolls in the GM queue window to reveal monster stats.
 5. **Bulk Upload Knowledge**: Use the bulk upload feature to grant players knowledge of multiple monsters at once. (Intended for use before or after game time)
+
+#### PLAYERS:
+
+1. **Token Identification**: If a token is unknown it will appear with a black silhouette. You cannot perform actions on this token until you have identified it. Ask your gm to identify the monster. Once you learn the monsters identity its image will appear.
+2. **After Identification**: Depending on your GM's settings, either click the book in the top right corner of the token or left click on the identified Monster to open the Monster info window.
+3. **Monster Info Window**: This window displays health, ac, speed, and stats of the monster. You do not know these attributes until you have discerned them. Click on the corresponding button to send a request to your GM to discern a trait.
+4. **Use your new found knowledge to slay your enemies!**
 
 ## Setup
 
@@ -135,6 +144,22 @@ Base settings for the module should be already set up. If you wish to prepopulat
 ## Settings
 
 ### Core Display Settings
+
+- **Auto Reveal**
+
+  - **Name**: `autoReveal`
+  - **Hint**: Choose to auto reveal tokens to your players.
+  - **Type**: Boolean
+  - **Default**: `false`
+  - **Requires Reload**: `false`
+
+- **Use Left Click**
+
+  - **Name**: `useLeftClick`
+  - **Hint**: Change Monster Info to pop up on left click instead of when clicking the book symbol.
+  - **Type**: Boolean
+  - **Default**: `false`
+  - **Requires Reload**: `true`
 
 - **Monster Hiding Style**
   - **Name**: `hideStyle`

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "anewfoe",
   "title": "ANewFoe",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "compatibility": {
     "minimum": "12",
     "verified": "12"
@@ -23,8 +23,19 @@
       "path": "languages/en.json"
     }
   ],
+  "relationships": {
+    "systems": [
+      {
+        "id": "dnd5e",
+        "type": "system",
+        "compatibility": {
+          "minimum": "4.1.0"
+        }
+      }
+    ]
+  },
   "socket": true,
   "url": "https://github.com/TheDeckOfManyStrings/anewfoe",
-  "download": "https://github.com/TheDeckOfManyStrings/anewfoe/archive/refs/tags/1.0.1.zip",
-  "readme": "https://raw.githubusercontent.com/TheDeckOfManyStrings/anewfoe/refs/tags/1.0.1/README.md"
+  "download": "https://github.com/TheDeckOfManyStrings/anewfoe/archive/refs/tags/1.0.2.zip",
+  "readme": "https://raw.githubusercontent.com/TheDeckOfManyStrings/anewfoe/refs/tags/1.0.2/README.md"
 }

--- a/scripts/anewfoe.js
+++ b/scripts/anewfoe.js
@@ -1205,6 +1205,16 @@ class ANewFoe {
       },
     });
 
+    game.settings.register(this.ID, "useLeftClick", {
+      name: "Use Left Click for Monster Info",
+      hint: "When enabled, left-clicking a monster opens the info window. When disabled, a hover button will appear instead, allowing other modules to use left-click. Note: If turned on, this will override players left-click functionality. Turning this on is known to have adverse effects with modules like Argon Combat HUD.",
+      scope: "world",
+      config: true,
+      type: Boolean,
+      default: false,
+      requiresReload: true,
+    });
+
     game.settings.register(this.ID, "hideStyle", {
       name: "Monster Hiding Style",
       hint: "Choose how unidentified monsters appear to players",
@@ -1731,57 +1741,119 @@ class ANewFoe {
    */
   static _makeTokenClickable(token) {
     try {
-      if (!token || !token.actor) {
-        return;
+      if (!token || !token.actor) return;
+
+      const useLeftClick = game.settings.get(this.ID, "useLeftClick");
+      const userLevel = token.actor.getUserLevel(game.user.id);
+
+      // Only add hover button if not owner/observer and monster is revealed
+      if (
+        !useLeftClick &&
+        userLevel < CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER &&
+        ANewFoe.isMonsterRevealed(token.document)
+      ) {
+        // Create hover button if it doesn't exist
+        if (!token.monsterInfoButton) {
+          const button = new PIXI.Container();
+
+          // Create sprite using proper PIXI v4+ syntax
+          const texture = PIXI.Texture.from("icons/svg/book.svg");
+          const icon = new PIXI.Sprite(texture);
+          icon.width = 24;
+          icon.height = 24;
+          icon.alpha = 0.8;
+
+          const bg = new PIXI.Graphics();
+          bg.beginFill(0x000000, 0.5);
+          // bg.drawCircle(12, 12, 14);
+          bg.drawRoundedRect(0, 0, 32, 32, 6);
+          bg.endFill();
+
+          icon.anchor.set(0.5); // Set anchor to center
+          icon.position.set(bg.width / 2, bg.height / 2); // Center icon in bg
+
+          button.addChild(bg);
+          button.addChild(icon);
+          button.position.set(token.w - 32, 0);
+          button.alpha = 0;
+          button.eventMode = "static"; // New PIXI v7 way to make interactive
+          button.cursor = "pointer"; // New PIXI v7 way to set cursor
+
+          button.on("pointerover", () => (button.alpha = 1));
+          button.on("pointerout", () => (button.alpha = 0));
+          button.on("click", async () => {
+            if (game.settings.get(ANewFoe.ID, "enableStatReveal")) {
+              await ANewFoe.showTokenInfo(token);
+            }
+          });
+
+          token.addChild(button);
+          token.monsterInfoButton = button;
+        }
+
+        // Show button on hover
+        token.eventMode = "static"; // Enable events on token
+        token.on("mouseover", () => {
+          if (token.monsterInfoButton) token.monsterInfoButton.alpha = 1;
+        });
+        token.on("mouseout", () => {
+          if (token.monsterInfoButton) token.monsterInfoButton.alpha = 0;
+        });
       }
 
-      token.interactive = true;
-      token.buttonMode = true;
-
+      // Handle click behavior based on settings
       if (token.mouseInteractionManager) {
-        token.mouseInteractionManager.permissions.clickLeft = true;
-        token.mouseInteractionManager.callbacks.clickLeft = async (event) => {
-          try {
-            event.preventDefault();
-            event.stopPropagation();
+        if (useLeftClick) {
+          token.mouseInteractionManager.permissions.clickLeft = true;
+          token.mouseInteractionManager.callbacks.clickLeft = async (event) => {
+            try {
+              event.preventDefault();
+              event.stopPropagation();
 
-            const userId = game.user.id;
-            if (!token.actor) {
-              console.warn(
-                `${this.ID} | Actor not available for token:`,
-                token.name
-              );
-              return;
-            }
-
-            const userPermissionLevel = token.actor.getUserLevel(userId);
-
-            if (userPermissionLevel >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER) {
-              return token._onClickLeft(event);
-            }
-
-            if (ANewFoe.isMonsterRevealed(token.document)) {
-              if (game.settings.get(ANewFoe.ID, "enableStatReveal")) {
-                await ANewFoe.showTokenInfo(token);
+              const userId = game.user.id;
+              if (!token.actor) {
+                console.warn(
+                  `${this.ID} | Actor not available for token:`,
+                  token.name
+                );
+                return;
               }
-            }
-          } catch (error) {
-            console.error(`${this.ID} | Error in click handler:`, error);
-          }
-        };
 
+              const userPermissionLevel = token.actor.getUserLevel(userId);
+              if (
+                userPermissionLevel >= CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
+              ) {
+                return token._onClickLeft(event);
+              }
+
+              if (ANewFoe.isMonsterRevealed(token.document)) {
+                if (game.settings.get(ANewFoe.ID, "enableStatReveal")) {
+                  await ANewFoe.showTokenInfo(token);
+                }
+              }
+            } catch (error) {
+              console.error(`${this.ID} | Error in click handler:`, error);
+            }
+          };
+        } else {
+          // Allow default left-click behavior
+          token.mouseInteractionManager.permissions.clickLeft = true;
+          token.mouseInteractionManager.callbacks.clickLeft =
+            token._onClickLeft.bind(token);
+        }
+
+        // Restrict other interactions for non-owners
         if (
-          token.actor &&
           token.actor.getUserLevel(game.user.id) <
-            CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
+          CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER
         ) {
           token.mouseInteractionManager.permissions.clickLeft2 = false;
-          token.mouseInteractionManager.permissions.clickRight = false;
           token.mouseInteractionManager.permissions.dragLeft = false;
           token.mouseInteractionManager.permissions.dragRight = false;
         }
       }
 
+      // Always allow right-click targeting
       token.on("rightdown", (event) => {
         if (event.data.originalEvent.detail === 2) {
           token.setTarget(!token.isTargeted, { releaseOthers: false });
@@ -1957,6 +2029,12 @@ class ANewFoe {
         if (token.mesh && token.mesh.texture) {
           await token.refresh();
         }
+
+        // Remove info button if it exists
+        if (token.monsterInfoButton) {
+          token.monsterInfoButton.destroy();
+          token.monsterInfoButton = null;
+        }
       }
     } catch (error) {
       console.error(`${this.ID} | Error processing token visibility:`, error);
@@ -1980,6 +2058,11 @@ class ANewFoe {
 
       token.document.texture.tint = originalTint || 0xffffff;
       if (originalName) token.document.name = originalName;
+
+      // Reapply hover button if needed
+      if (!game.settings.get(this.ID, "useLeftClick")) {
+        this._makeTokenClickable(token);
+      }
 
       await token.refresh();
     } catch (error) {

--- a/styles/anewfoe.css
+++ b/styles/anewfoe.css
@@ -361,3 +361,23 @@
   padding: 4px;
   margin-top: 20px;
 }
+
+/* Add styles for the hover button */
+.monster-info-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.monster-info-button:hover {
+  background: rgba(0, 0, 0, 0.8);
+}


### PR DESCRIPTION
Add in game settings to allow for automatic reveal of monster to all players and to add a button to the token hud instead of overriding the left click button. 